### PR TITLE
Remove deprecated PHP code

### DIFF
--- a/libs/db_lib/mysql.php
+++ b/libs/db_lib/mysql.php
@@ -101,7 +101,6 @@ class SQL //MySQL
   if( is_array($value) ) {
     return array_map( array(&$this,'quote_smart') , $value);
   } else {
-    if( get_magic_quotes_gpc() ) $value = stripslashes($value);
     if( $value === '' ) $value = NULL;
     if (function_exists('mysql_real_escape_string'))
       return mysql_real_escape_string($value, $this->link_id);

--- a/libs/db_lib/mysqli.php
+++ b/libs/db_lib/mysqli.php
@@ -105,7 +105,6 @@ class SQL //MySQLi
     if( is_array($value) ) {
         return array_map( array('SQL','quote_smart') , $value);
     } else {
-        if( get_magic_quotes_gpc() ) $value = stripslashes($value);
         if( $value === '' ) $value = NULL;
         return mysqli_real_escape_string($this->link_id, $value);
         }

--- a/libs/valid_lib.php
+++ b/libs/valid_lib.php
@@ -77,9 +77,6 @@ function cleanSQL($string)
 {
     global $mmfpm_db;
     
-    if(get_magic_quotes_gpc())  // prevents duplicate backslashes
-        $string = stripslashes($string);
-
     if (phpversion() >= '7.0')
         {
             $sqlm = new mysqli($mmfpm_db['addr'], $mmfpm_db['user'], $mmfpm_db['pass'], $mmfpm_db['name']);


### PR DESCRIPTION
Using PHP 7.4.1 shows deprecation about get_magic_quotes_gpc() and hits a breakpoint there while debugging it